### PR TITLE
[TASK] re-add 8LTS compat for v1.2

### DIFF
--- a/Classes/Core/DBLayer.php
+++ b/Classes/Core/DBLayer.php
@@ -47,11 +47,17 @@ class DBLayer
 
     public function fetch(\Doctrine\DBAL\Driver\Statement $res)
     {
+        if (!class_exists(\Doctrine\DBAL\FetchMode::class)) {
+            return $res->fetch(\PDO::FETCH_ASSOC);
+        }
         return $res->fetch(\Doctrine\DBAL\FetchMode::ASSOCIATIVE);
     }
 
     public function fetch_row(\Doctrine\DBAL\Driver\Statement $res)
     {
+        if (!class_exists(\Doctrine\DBAL\FetchMode::class)) {
+            return $res->fetch(\PDO::FETCH_ASSOC);
+        }
         return $res->fetch(\Doctrine\DBAL\FetchMode::ASSOCIATIVE);
     }
 


### PR DESCRIPTION
As the v1.2 step improves php 7.2 compatibility and 8LTS is still not EOL, the v1.2 should support 8LTS again